### PR TITLE
Potential fix for code scanning alert no. 82: Incomplete regular expression for hostnames

### DIFF
--- a/Games/html5-games/1v1.lol/patch/google/ima3-o.js
+++ b/Games/html5-games/1v1.lol/patch/google/ima3-o.js
@@ -13858,7 +13858,7 @@
     var Vw = RegExp("/pagead/conversion|/pagead/adview|/pagead/gen_204|/activeview?|csi.gstatic.com/csi|google.com/pagead/xsul|google.com/ads/measurement/l|googleads.g.doubleclick.net/pagead/ide_cookie|googleads.g.doubleclick.net/xbbe/pixel")
       , Ww = RegExp("outstream.min.js")
       , Xw = RegExp("outstream.min.css")
-      , Yw = RegExp("fonts.gstatic.com")
+      , Yw = RegExp("fonts\\.gstatic\\.com")
       , Zw = RegExp("googlevideo.com/videoplayback|c.2mdn.net/videoplayback|gcdn.2mdn.net/videoplayback")
       , $w = RegExp("custom.elements.min.js");
     function ax(a, b) {


### PR DESCRIPTION
Potential fix for [https://github.com/ekoerp1/Nooby/security/code-scanning/82](https://github.com/ekoerp1/Nooby/security/code-scanning/82)

To fix the problem, we need to escape the `.` meta-character in the regular expression to ensure it only matches a literal dot. This will prevent unintended matches and improve the accuracy of the host validation.

- Locate the regular expression on line 13861 in the file `Games/html5-games/1v1.lol/patch/google/ima3-o.js`.
- Modify the regular expression to escape the `.` before `gstatic.com` by replacing it with `\.`.
- No additional methods, imports, or definitions are needed to implement this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
