### PR TITLE
Potential fix for code scanning alert no. 103: Useless regular-expression character escape

### DIFF
--- a/Games/html5-games/cookieclicker/main.js
+++ b/Games/html5-games/cookieclicker/main.js
@@ -2244,7 +2244,7 @@ Game.Launch=function()
 			}
 			catch(e)
 			{
-				var exp=new RegExp('\W+','g');
+				var exp=new RegExp('\\W+','g');
 				Game.bakeryName=what.replace(exp,' ');
 				//Game.bakeryName=what.replace(/\W+/g,' ');
 				Game.bakeryName=Game.bakeryName.substring(0,28);


### PR DESCRIPTION
Potential fix for [https://github.com/ekoerp1/Nooby/security/code-scanning/103](https://github.com/ekoerp1/Nooby/security/code-scanning/103)

To fix the problem, we need to ensure that the escape sequence `\W` is correctly interpreted as a character class in the regular expression. This can be achieved by using a double backslash `\\W` in the string literal, which will be correctly interpreted as `\W` in the regular expression.

- Change the escape sequence `\W` to `\\W` on line 2247.
- This change ensures that the regular expression correctly matches any non-word character.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
