### PR TITLE
Potential fix for code scanning alert no. 80: Incomplete regular expression for hostnames

### DIFF
--- a/Games/html5-games/1v1.lol/patch/google/ima3-o.js
+++ b/Games/html5-games/1v1.lol/patch/google/ima3-o.js
@@ -13855,7 +13855,7 @@
         P.prototype.M.call(this)
     }
     ;
-    var Vw = RegExp("/pagead/conversion|/pagead/adview|/pagead/gen_204|/activeview?|csi.gstatic.com/csi|google.com/pagead/xsul|google.com/ads/measurement/l|googleads.g.doubleclick.net/pagead/ide_cookie|googleads.g.doubleclick.net/xbbe/pixel")
+    var Vw = RegExp("/pagead/conversion|/pagead/adview|/pagead/gen_204|/activeview?|csi.gstatic.com/csi|google.com/pagead/xsul|google.com/ads/measurement/l|googleads\\.g\\.doubleclick\\.net/pagead/ide_cookie|googleads\\.g\\.doubleclick\\.net/xbbe/pixel")
       , Ww = RegExp("outstream.min.js")
       , Xw = RegExp("outstream.min.css")
       , Yw = RegExp("fonts\\.gstatic\\.com")


### PR DESCRIPTION
Potential fix for [https://github.com/ekoerp1/Nooby/security/code-scanning/80](https://github.com/ekoerp1/Nooby/security/code-scanning/80)

To fix the problem, we need to escape the dot in the regular expression to ensure it matches only a literal dot and not any character. This will make the regular expression more precise and prevent unintended matches.

- Locate the regular expression on line 13858 in the file `Games/html5-games/1v1.lol/patch/google/ima3-o.js`.
- Modify the regular expression to escape the dot before `doubleclick.net` by replacing `.` with `\.`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
