### PR TITLE
Potential fix for code scanning alert no. 2: Prototype-polluting function

### DIFF
--- a/Games/html5-games/1v1.lol/ifr.htm
+++ b/Games/html5-games/1v1.lol/ifr.htm
@@ -61,7 +61,7 @@ window['___cfg'] = window['___cfg'] || window['___gcfg'];;
 if(!window.gadgets["config"]){gadgets.config=function(){var f;
 var h={};
 var b={};
-function c(j,l){for(var k in l){if(!l.hasOwnProperty(k)){continue
+function c(j,l){for(var k in l){if(!l.hasOwnProperty(k) || k === "__proto__" || k === "constructor"){continue
 }if(typeof j[k]==="object"&&typeof l[k]==="object"){c(j[k],l[k])
 }else{j[k]=l[k]
 }}}function i(){var j=document.scripts||document.getElementsByTagName("script");


### PR DESCRIPTION
Potential fix for [https://github.com/ekoerp1/Nooby/security/code-scanning/2](https://github.com/ekoerp1/Nooby/security/code-scanning/2)

To fix the problem, we need to ensure that the function `c` does not copy special properties like `__proto__` and `constructor` that can lead to prototype pollution. This can be achieved by adding checks to skip these properties during the merge process.

- Modify the function `c` to include checks that skip the properties `__proto__` and `constructor`.
- Ensure that these checks are applied before any assignment or recursive call within the function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
