### PR TITLE
Potential fix for code scanning alert no. 78: Incomplete regular expression for hostnames

### DIFF
--- a/Games/html5-games/1v1.lol/patch/google/ima3-o.js
+++ b/Games/html5-games/1v1.lol/patch/google/ima3-o.js
@@ -11645,7 +11645,7 @@
         return u.navigator ? u.navigator.userAgent : ""
     }, Lt = kb(Kt(), "(iPad") || kb(Kt(), "(Macintosh") || kb(Kt(), "(iPod") || kb(Kt(), "(iPhone");
     var Mt = "ad.doubleclick.net bid.g.doubleclick.net ggpht.com google.co.uk google.com googleads.g.doubleclick.net googleads4.g.doubleclick.net googleadservices.com googlesyndication.com googleusercontent.com gstatic.com gvt1.com prod.google.com pubads.g.doubleclick.net s0.2mdn.net static.doubleclick.net surveys.g.doubleclick.net youtube.com ytimg.com".split(" ")
-      , Nt = ["c.googlesyndication.com"];
+      , Nt = ["c\\.googlesyndication\\.com"];
     function Ot(a, b) {
         b = void 0 === b ? window.location.protocol : b;
         var c = !1;


### PR DESCRIPTION
Potential fix for [https://github.com/ekoerp1/Nooby/security/code-scanning/78](https://github.com/ekoerp1/Nooby/security/code-scanning/78)

To fix the problem, we need to ensure that all `.` characters in the hostnames are properly escaped in the regular expression. This will prevent unintended matches and ensure that only the specified hostnames are allowed.

- Locate the line where the hostnames are defined (line 11648).
- Escape the `.` characters in the hostname `c.googlesyndication.com` by replacing it with `c\.googlesyndication\.com`.
- Ensure that the regular expression construction on line 11679 correctly uses the escaped hostnames.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
