### PR TITLE
Potential fix for code scanning alert no. 83: Incomplete regular expression for hostnames

### DIFF
--- a/Games/html5-games/1v1.lol/patch/google/ima3-o.js
+++ b/Games/html5-games/1v1.lol/patch/google/ima3-o.js
@@ -13859,7 +13859,7 @@
       , Ww = RegExp("outstream.min.js")
       , Xw = RegExp("outstream.min.css")
       , Yw = RegExp("fonts\\.gstatic\\.com")
-      , Zw = RegExp("googlevideo.com/videoplayback|c.2mdn.net/videoplayback|gcdn.2mdn.net/videoplayback")
+      , Zw = RegExp("googlevideo.com/videoplayback|c\\.2mdn.net/videoplayback|gcdn\\.2mdn.net/videoplayback")
       , $w = RegExp("custom.elements.min.js");
     function ax(a, b) {
         var c = 0


### PR DESCRIPTION
Potential fix for [https://github.com/ekoerp1/Nooby/security/code-scanning/83](https://github.com/ekoerp1/Nooby/security/code-scanning/83)

To fix the problem, we need to escape the `.` character in the regular expression to ensure it matches a literal dot rather than any character. This can be done by replacing `.` with `\\.` in the regular expression. Specifically, we need to update the regular expression on line 13862 to escape the dot before `2mdn.net`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
